### PR TITLE
ALPS-3486: Add https to artstor reporting url

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -23,7 +23,7 @@
       "IMAGE_GROUPS": "Image Groups"
     },
     "ARTSTOR_STATS": {
-      "CONTENT": "For usage statistics go to the <a href='http://report.artstor.org/' target='_blank'>Artstor Stats Site</a>"
+      "CONTENT": "For usage statistics go to the <a href='https://report.artstor.org/' target='_blank'>Artstor Stats Site</a>"
     },
     "QUESTIONS_TRAINING": {
       "HDR": "Questions & training",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Prevents breaking of routing. 

* **What is the current behavior?** (You can also link to an open issue here)
Some users have issues when the url is `http` vs `https`


* **What is the new behavior (if this is a feature change)?**



* **Other information**:
