### PR TITLE
ALPS-3564: Updated days remaining text for access

### DIFF
--- a/src/app/modals/user-details/user-details-modal.component.pug
+++ b/src/app/modals/user-details/user-details-modal.component.pug
@@ -32,7 +32,7 @@ form#formPermissions(
           td {{ user.timeLastAccessed | date }}
         tr
           td Remote login access
-          td {{ user.daysAccessRemaining > 0 && user.daysAccessRemaining days remaining
+          td {{ user.daysAccessRemaining > 0 && user.daysAccessRemaining days remaining }}
     h6 Permissions
     fieldset([disabled]="user.archivedUser")
       ul.list-group.form-group.pb-3

--- a/src/app/modals/user-details/user-details-modal.component.pug
+++ b/src/app/modals/user-details/user-details-modal.component.pug
@@ -32,7 +32,7 @@ form#formPermissions(
           td {{ user.timeLastAccessed | date }}
         tr
           td Remote login access
-          td {{ user.daysAccessRemaining > 0 && user.daysAccessRemaining days remaining }}
+          td {{ user.daysAccessRemaining > 0 ? user.daysAccessRemaining : 0 }} days remaining
     h6 Permissions
     fieldset([disabled]="user.archivedUser")
       ul.list-group.form-group.pb-3

--- a/src/app/modals/user-details/user-details-modal.component.pug
+++ b/src/app/modals/user-details/user-details-modal.component.pug
@@ -32,7 +32,7 @@ form#formPermissions(
           td {{ user.timeLastAccessed | date }}
         tr
           td Remote login access
-          td {{ user.daysAccessRemaining > 0 ? user.daysAccessRemaining : 0 }} of 120 days remaining
+          td {{ user.daysAccessRemaining > 0 && user.daysAccessRemaining days remaining
     h6 Permissions
     fieldset([disabled]="user.archivedUser")
       ul.list-group.form-group.pb-3


### PR DESCRIPTION
[Addresses ALPS-3564](https://jira.jstor.org/browse/ALPS-3564)
 
----
  
## The Problem
  
We had hardcoded timeframe stated as " of 120 days remaining". This language is confusing when a user gets a full year of access.

## Why This Solution?

This ticket removed the hardcoded date and only displays the number of days left a user has with access. 
----
 
## Screenshots
 
### Before
*What did the UI look like before this change?*
![Screen Shot 2021-03-10 at 12 19 42 PM](https://user-images.githubusercontent.com/10200622/114180315-0a84cf80-990e-11eb-936b-f7b694c29713.png)

 
### After
*What does the UI look like after this change?*
![Screen Shot 2021-04-09 at 8 30 50 AM](https://user-images.githubusercontent.com/10200622/114180333-11abdd80-990e-11eb-9199-654f376b3112.png)
