### PR TITLE
Switch to use Artifactory to avoid rate limit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 #    Run image as virtual host (read more: https://github.com/jwilder/nginx-proxy):
 #    docker run -e VIRTUAL_HOST=angular-starter.your-domain.com --name angular-starter angular-starter &
 
-FROM nginx:1.13.0-alpine
+FROM docker-vitual.artifactory.acorn.cirrostratus.org/nginx:1.13.0-alpine
 
 # install console and node
 RUN apk add --no-cache bash=4.3.46-r5 &&\


### PR DESCRIPTION
Please use docker-virtual for all image pulls from Dockerhub or related cached repositories.  Failure to do so will cause service outage, build failures, or other problems with your system and it will happen randomly and unexpectedly.

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
This fixes a hazard with rate limit to pull image which will result in an incident if not fixed. 


* **What is the current behavior?** (You can also link to an open issue here)
Image pulls will fail if not cached on the given node or on the system, experience will be random and non-deterministic.  Remediation when incident occurs will be this exact PR, causing a new build, and deploy. 

* **What is the new behavior (if this is a feature change)?**
It will pull from Artifactory, and be successful 99.9% of the time. 


* **Other information**:
