### PR TITLE
ALPS-4615: Update promotional materials to proper URL

### DIFF
--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -32,7 +32,7 @@
     },
     "PROMO": {
       "HDR": "Need materials to promote Artstor at your institution?",
-      "CONTENT": "<span>Go to </span><a href='http://support.artstor.org/?article=promoting-artstor-on-campus' target='_blank'>Promotional materials</a><span> for more information.</span>"
+      "CONTENT": "<span>Go to </span><a href='https://support.artstor.org/hc/en-us/articles/360021193094?article=promoting-artstor-on-campus' target='_blank'>Promotional materials</a><span> for more information.</span>"
     },
     "LOCAL_SUPPORT": {
       "HDR": "Local support information",


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Updating link for `Promotional Materials`

* **What is the current behavior?** (You can also link to an open issue here)

link was redirecting users to `https://support.artstor.org/hc/en-us`

* **What is the new behavior (if this is a feature change)?**

Link should be redirecting users to `https://support.artstor.org/hc/en-us/articles/360021193094?article=promoting-artstor-on-campus`
