### PR TITLE
CVE-2023-45133: Add babel traverse to resolutions in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -181,5 +181,8 @@
   "engines": {
     "node": ">=10.13.0",
     "npm": ">= 5"
+  },
+  "resolutions": {
+    "@babel/traverse": "^7.23.2"
   }
 }


### PR DESCRIPTION
[CVE-2023-45133](https://github.com/advisories/GHSA-67hx-6x53-jw92)

Add `@babel/traverse: ^7.23.2` to resolutions in `package.json`.